### PR TITLE
Fix 判断是否在线不应该使用equipNet 而是使用status

### DIFF
--- a/custom_components/cloud_gps/tuqiang123_data_fetcher.py
+++ b/custom_components/cloud_gps/tuqiang123_data_fetcher.py
@@ -193,11 +193,11 @@ class DataFetcher:
                                   
                 thislat = float(data["lat"])
                 thislon = float(data["lng"])
-                
-                if data['equipNet'] == "0":
-                    status = "在线"
-                else:
+
+                status = "在线"
+                if data['status'] == "OFFLINE":
                     status = "离线"
+        
                 if data["status"] == "STATIC":
                     runorstop = "静止"
                     speed = 0
@@ -206,6 +206,10 @@ class DataFetcher:
                     runorstop = "运动"
                     speed = float(data.get("speed",0))
                     parkingtime = ""
+                elif data["status"] == "OFFLINE":
+                    runorstop = "离线"
+                    speed = 0
+                    parkingtime = data["statusStr"]
                 else:
                     runorstop = "未知"
                     speed = 0


### PR DESCRIPTION
根据对接口数据的差异对比得出 
![image](https://github.com/dscao/cloud_gps/assets/28857775/5a4a4f32-c0d0-46fc-af39-3c75fcd3f481)

tuqiang123_data_fetcher.py 
判断设备是否在线不应该使用equipNet 而是使用status的OFFLINE状态
