### PR TITLE
途强在线增加里程获取接口,增加了今日里程,昨日里程,本月里程及今年里程的获取及展示

### DIFF
--- a/custom_components/cloud_gps/__init__.py
+++ b/custom_components/cloud_gps/__init__.py
@@ -354,6 +354,52 @@ class CloudDataUpdateCoordinator(DataUpdateCoordinator):
                                     self._address[imei] = await self._get_address_frome_api(imei, self._addressapi, self._api_key, self._private_key)
                                     _LOGGER.debug("api_get_address: %s", self._address.get(imei))
                                 data[imei]["attrs"]["address"] = self._address.get(imei)
+                            # ========== 今日里程获取 ==========
+                            try:
+                                today_data = await self._fetcher.get_today_mileage()  # 正确的方式
+                                today_dis = today_data.get(imei, {}).get("today_dis", 0)
+                                if "attrs" not in data[imei]:
+                                    data[imei]["attrs"] = {}
+                                data[imei]["attrs"]["today_dis"] = today_dis
+
+                                _LOGGER.debug("今日里程数据 for %s: %s", imei, today_dis)
+
+                            except Exception as e:
+                                _LOGGER.warning("获取今日里程失败 for %s: %s", imei, str(e))
+                                today_dis = 0
+                            # ========== 昨日里程获取 ==========
+                            try:
+                                yesterday_data = await self._fetcher.get_yesterday_mileage()  # 正确的方式
+                                yesterday_dis = yesterday_data.get(imei, {}).get("yesterday_dis", 0)
+                                if "attrs" not in data[imei]:
+                                    data[imei]["attrs"] = {}
+                                data[imei]["attrs"]["yesterday_dis"] = yesterday_dis
+                                _LOGGER.debug("昨日里程数据 for %s: %s", imei, yesterday_dis)
+                            except Exception as e:
+                                _LOGGER.warning("获取昨日里程失败 for %s: %s", imei, str(e))
+                                yesterday_dis = 0
+                            # ========== 本月里程获取 ==========
+                            try:
+                                month_data = await self._fetcher.get_month_mileage()  # 正确的方式
+                                month_dis = month_data.get(imei, {}).get("month_dis", 0)
+                                if "attrs" not in data[imei]:
+                                    data[imei]["attrs"] = {}
+                                data[imei]["attrs"]["month_dis"] = month_dis
+                                _LOGGER.debug("昨日里程数据 for %s: %s", imei, month_dis)
+                            except Exception as e:
+                                _LOGGER.warning("获取本月里程失败 for %s: %s", imei, str(e))
+                                month_dis = 0
+                            # ========== 今年里程获取 ==========
+                            try:
+                                year_data = await self._fetcher.get_year_mileage()  # 正确的方式
+                                year_dis = year_data.get(imei, {}).get("year_dis", 0)
+                                if "attrs" not in data[imei]:
+                                    data[imei]["attrs"] = {}
+                                data[imei]["attrs"]["year_dis"] = year_dis
+                                _LOGGER.debug("昨日里程数据 for %s: %s", imei, year_dis)
+                            except Exception as e:
+                                _LOGGER.warning("获取今年里程失败 for %s: %s", imei, str(e))
+                                year_dis = 0
                     # 保存新数据
                     self.data = data
         

--- a/custom_components/cloud_gps/config_flow.py
+++ b/custom_components/cloud_gps/config_flow.py
@@ -46,6 +46,10 @@ from .const import (
     CONF_ADDRESSAPI_KEY,
     CONF_PRIVATE_KEY,
     CONF_WITH_MAP_CARD,
+    KEY_TODAY_DIS,
+    KEY_YESTERDAY_DIS,
+    KEY_MONTH_DIS,
+    KEY_YEAR_DIS,
 )
 
 import voluptuous as vol
@@ -799,7 +803,11 @@ class OptionsFlow(config_entries.OptionsFlow):
                 {"value": KEY_TOTALKM, "label": "totalkm"},
                 {"value": KEY_STATUS, "label": "status"},
                 {"value": KEY_ACC, "label": "acc"},
-                {"value": KEY_BATTERY, "label": "powbattery"}
+                {"value": KEY_BATTERY, "label": "powbattery"},
+                {"value": KEY_TODAY_DIS, "label": "today_dis"},
+                {"value": KEY_YESTERDAY_DIS, "label": "yesterday_dis"},
+                {"value": KEY_MONTH_DIS, "label": "month_dis"},
+                {"value": KEY_YEAR_DIS, "label": "year_dis"}
             ]
             SWITCHSLIST = []
             BUTTONSLIST = [

--- a/custom_components/cloud_gps/const.py
+++ b/custom_components/cloud_gps/const.py
@@ -73,4 +73,7 @@ KEY_RUNORSTOP = "runorstop"
 KEY_SHAKE = "shake"
 KEY_BATTERY = "powbattery"
 KEY_BATTERY_STATUS = "battery_status"
-
+KEY_TODAY_DIS = "today_dis"
+KEY_YESTERDAY_DIS = "yesterday_dis"
+KEY_MONTH_DIS = "month_dis"
+KEY_YEAR_DIS = "year_dis"

--- a/custom_components/cloud_gps/sensor.py
+++ b/custom_components/cloud_gps/sensor.py
@@ -32,6 +32,10 @@ from .const import (
     KEY_BATTERY_STATUS,
     KEY_RUNORSTOP,
     KEY_SHAKE,
+    KEY_TODAY_DIS,
+    KEY_YESTERDAY_DIS,
+    KEY_MONTH_DIS,
+    KEY_YEAR_DIS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -104,7 +108,35 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key=KEY_LASTSEEN,
         name="lastseen",
         icon="mdi:eye-check"
-    )
+    ),
+    SensorEntityDescription(
+        key=KEY_TODAY_DIS,
+        name="today_dis",
+        unit_of_measurement="km",
+        device_class="distance",
+        icon="mdi:map-marker-distance",
+    ),
+    SensorEntityDescription(
+        key=KEY_YESTERDAY_DIS,
+        name="yesterday_dis",
+        unit_of_measurement="km",
+        device_class="distance",
+        icon="mdi:map-marker-distance",
+    ),
+    SensorEntityDescription(
+        key=KEY_MONTH_DIS,
+        name="month_dis",
+        unit_of_measurement="km",
+        device_class="distance",
+        icon="mdi:map-marker-distance",
+    ),
+    SensorEntityDescription(
+        key=KEY_YEAR_DIS,
+        name="year_dis",
+        unit_of_measurement="km",
+        device_class="distance",
+        icon="mdi:map-marker-distance",
+    ),
 )
 
 SENSOR_TYPES_MAP = { description.key: description for description in SENSOR_TYPES }
@@ -257,7 +289,14 @@ class CloudGPSSensorEntity(CoordinatorEntity):
                 self._state = attrs.get("battery_status")
             elif self.entity_description.key == "status":
                 self._state = self.coordinator.data[self._imei].get("status")
-            
+            elif self.entity_description.key == "today_dis":
+                self._state = attrs.get("today_dis")
+            elif self.entity_description.key == "yesterday_dis":
+                self._state = attrs.get("yesterday_dis")
+            elif self.entity_description.key == "month_dis":
+                self._state = attrs.get("month_dis")
+            elif self.entity_description.key == "year_dis":
+                self._state = attrs.get("year_dis")
             self._attrs = {"querytime": attrs.get("querytime")}
             
         else:

--- a/custom_components/cloud_gps/translations/zh-Hans.json
+++ b/custom_components/cloud_gps/translations/zh-Hans.json
@@ -71,7 +71,11 @@
                 "runorstop": "运动状态",
                 "shake": "震动状态",
                 "battery_status": "电池状态",
-                "powbattery": "电池电压"
+                "powbattery": "电池电压",
+				"today_dis": "今日里程",
+				"yesterday_dis": "昨日里程",
+				"month_dis": "本月里程",
+				"year_dis": "今年里程"
 			}
 		},
         "switchs": {
@@ -317,6 +321,38 @@
 			},
             "lastseen": {
 				"name": "最后一次出现",
+				"state_attributes": {
+					"querytime": {
+					  "name": "查询时间"
+					}
+				}
+			},
+            "today_dis": {
+				"name": "今日里程",
+				"state_attributes": {
+					"querytime": {
+					  "name": "查询时间"
+					}
+				}
+			},
+            "yesterday_dis": {
+				"name": "昨日里程",
+				"state_attributes": {
+					"querytime": {
+					  "name": "查询时间"
+					}
+				}
+			},
+			"month_dis": {
+				"name": "本月里程",
+				"state_attributes": {
+					"querytime": {
+					  "name": "查询时间"
+					}
+				}
+			},
+            "year_dis": {
+				"name": "今年里程",
 				"state_attributes": {
 					"querytime": {
 					  "name": "查询时间"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/596e07dd-0760-4df0-8651-19366fe6e50e)
从没写过HA插件 依样画葫芦照着写的 比较粗糙 图中的总里程是从接口中获取的总里程 这个里程是可以自己在APP或者WEB中定义的  其余的里程数据是根据途强的报表接口取出来的 我测试了这四个接口的返回时长都是一样的 应该不会过多增加服务器压力,,,(猜测) 后面想把昨日接口做成每次启动HA或者每晚12点运行一次即可 本月和今年里程做成1小时一次 但不知道怎么写代码了~